### PR TITLE
Clangd: Add clangd parameters in IDE agnostic config file

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -4,6 +4,10 @@ CompileFlags:
         - -Wno-format
     Remove: 
         - -mword-relocations
+    CompilationDatabase: "./build/latest"
+
+Completion:
+    HeaderInsertion: Never
 
 Diagnostics:
     ClangTidy:


### PR DESCRIPTION
Imported from upstream: https://github.com/flipperdevices/flipperzero-firmware/pull/4319
Original author: @WillyJL

---

# What's new

- Clangd now works in other IDE's without IDE specific configuration, eg Zed editor

# Verification 

- Compile firmare, open other editor with clangd support (eg Zed), open a C file, clangd goes through indexing and diagnostics work as expected

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
